### PR TITLE
Prevent form submit

### DIFF
--- a/src/components/table.js
+++ b/src/components/table.js
@@ -154,6 +154,7 @@ export default (comps, { modal, ...config }) => {
         const containerBtn = document.createElement("div");
         containerBtn.className = "modal-create-btn";
         const btn = document.createElement("button");
+        btn.setAttribute("type", "button");
         btn.innerHTML = "Create Table";
         btn.onclick = () => {
           this.model.set("rows", setRows);


### PR DESCRIPTION
The button of the modal dialog to create the table is of type "submit" by default. This submits any form GrapesJs is embedded in